### PR TITLE
feat: 添加播放速度控制功能

### DIFF
--- a/src/i18n/lang/en-US/player.ts
+++ b/src/i18n/lang/en-US/player.ts
@@ -58,7 +58,8 @@ export default {
     next: 'Next',
     volume: 'Volume',
     favorite: 'Favorite {name}',
-    unFavorite: 'Unfavorite {name}'
+    unFavorite: 'Unfavorite {name}',
+    playbackSpeed: 'Playback Speed'
   },
   eq: {
     title: 'Equalizer',

--- a/src/i18n/lang/zh-CN/player.ts
+++ b/src/i18n/lang/zh-CN/player.ts
@@ -59,7 +59,8 @@ export default {
     volume: '音量',
     favorite: '已收藏{name}',
     unFavorite: '已取消收藏{name}',
-    miniPlayBar: '迷你播放栏'
+    miniPlayBar: '迷你播放栏',
+    playbackSpeed: '播放速度'
   },
   eq: {
     title: '均衡器',

--- a/src/renderer/components/player/PlayBar.vue
+++ b/src/renderer/components/player/PlayBar.vue
@@ -161,6 +161,23 @@
         </template>
         {{ t('player.playBar.playList') }}
       </n-tooltip>
+      <!-- 添加播放速度控制按钮 -->
+      <n-dropdown
+        v-if="!isMobile"
+        :options="playbackRateOptions"
+        @select="handlePlaybackRateChange"
+        trigger="click"
+        :z-index="9999999"
+      >
+        <n-tooltip trigger="hover" :z-index="9999999">
+          <template #trigger>
+            <div class="play-speed">
+              <span class="speed-button">{{ playbackRate }}x</span>
+            </div>
+          </template>
+          {{ t('player.playBar.playbackSpeed') }}
+        </n-tooltip>
+      </n-dropdown>
     </div>
     <!-- 播放音乐 -->
     <music-full ref="MusicFullRef" v-model="musicFullVisible" :background="background" />
@@ -318,6 +335,23 @@ const playModeText = computed(() => {
       return t('player.playBar.playMode.sequence');
   }
 });
+
+// 播放速度控制
+const playbackRate = ref(1.0);
+const playbackRateOptions = [
+  { label: '0.5x', key: 0.5 },
+  { label: '0.75x', key: 0.75 },
+  { label: '1.0x', key: 1.0 },
+  { label: '1.25x', key: 1.25 },
+  { label: '1.5x', key: 1.5 },
+  { label: '2.0x', key: 2.0 }
+];
+
+
+const handlePlaybackRateChange = (rate: number) => {
+  playbackRate.value = rate;
+  audioService.setPlaybackRate(rate);
+};
 
 // 切换播放模式
 const togglePlayMode = () => {
@@ -701,5 +735,25 @@ const openPlayListDrawer = () => {
   font-size: 24px;
   color: white;
   animation: spin 1s linear infinite;
+}
+
+.play-speed {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0 8px;
+}
+
+.speed-button {
+  font-size: 14px;
+  color: var(--text-color);
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--hover-color);
+}
+
+.speed-button:hover {
+  background: var(--hover-color-dark);
 }
 </style>

--- a/src/renderer/store/modules/player.ts
+++ b/src/renderer/store/modules/player.ts
@@ -399,6 +399,9 @@ export const usePlayerStore = defineStore('player', () => {
     value: 0
   }));
 
+  // 添加播放速度状态
+  const playbackRate = ref(1.0);
+
   // 清空播放列表
   const clearPlayAll = async () => {
     audioService.pause()
@@ -1042,6 +1045,23 @@ export const usePlayerStore = defineStore('player', () => {
     setPlayList(newPlayList);
   };
 
+  // 设置播放速度
+  const setPlaybackRate = (rate: number) => {
+    playbackRate.value = rate;
+    audioService.setPlaybackRate(rate);
+    // 保存到本地存储
+    localStorage.setItem('playbackRate', rate.toString());
+  };
+
+  // 初始化播放速度
+  const initializePlaybackRate = () => {
+    const savedRate = localStorage.getItem('playbackRate');
+    if (savedRate) {
+      playbackRate.value = parseFloat(savedRate);
+      audioService.setPlaybackRate(playbackRate.value);
+    }
+  };
+
   // 初始化播放状态
   const initializePlayState = async () => {
     const settingStore = useSettingsStore();
@@ -1093,6 +1113,7 @@ export const usePlayerStore = defineStore('player', () => {
         localStorage.removeItem('playProgress');
       }
     }
+    initializePlaybackRate();
   };
 
   const initializeFavoriteList = async () => {
@@ -1343,6 +1364,8 @@ export const usePlayerStore = defineStore('player', () => {
     playAudio,
     reparseCurrentSong,
     setPlayListDrawerVisible,
-    handlePause
+    handlePause,
+    playbackRate,
+    setPlaybackRate
   };
 });


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->
是否可以更新添加一个倍速播放功能 #233

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
现有播放器不支持改变播放速度，用户无法实现 0.5×、1.5×、2.0× 等快进/慢放需求。为了提升可用性和灵活性，决定在播放栏增加速度选择菜单，并支持 Media Session API 同步速率。

UI添加可供选择的速度选项，提供get方法来设置不同的速度播放。

```typescript
  public setPlaybackRate(rate: number) {
    if (!this.currentSound) return;
    this.playbackRate = rate;

    // Howler 的 rate() 在 html5 模式下不生效
    this.currentSound.rate(rate);

    // 取出底层 HTMLAudioElement，改原生 playbackRate
    const sounds = (this.currentSound as any)._sounds as any[];
    sounds.forEach(({ _node }) => {
      if (_node instanceof HTMLAudioElement) {
        _node.playbackRate = rate;
      }
    });

    // 同步给 Media Session UI
    if ('mediaSession' in navigator && 'setPositionState' in navigator.mediaSession) {
      navigator.mediaSession.setPositionState({
        duration: this.currentSound.duration(),
        playbackRate: rate,
        position: this.currentSound.seek() as number
      });
    }
  }
```
![屏幕截图 2025-05-19 181047(1)](https://github.com/user-attachments/assets/d76785e6-eaa5-480f-a7ef-ee4cbb6710cf)




### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->
feat(PlayBar, player, audioService): 添加播放速度控制功能

- 在 `PlayBar.vue` 中新增速度下拉菜单（0.5x~2.0x），并展示当前速率  
- 在 `store/modules/player.ts` 实现播放速度的本地存储  
- 在 `audioService.ts` 实现 `setPlaybackRate(rate)`，Web Audio & HTML5 Audio 双模式支持  



- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
