### PR TITLE
feat:添加了手动添加token的设置

### DIFF
--- a/src/i18n/lang/en-US/settings.ts
+++ b/src/i18n/lang/en-US/settings.ts
@@ -102,13 +102,18 @@ export default {
     proxyHostPlaceholder: 'Enter proxy host',
     proxyPort: 'Proxy Port',
     proxyPortPlaceholder: 'Enter proxy port',
-    realIP: 'RealIP Settings',
-    realIPDesc: 'Use realIP parameter with mainland China IP to resolve access restrictions abroad',
+    realIP: 'Real IP Settings',
+    realIPDesc: 'Due to restrictions, this project may be limited when used abroad. You can use the realIP parameter to pass in a domestic IP to solve the problem',
+    token: 'Token Settings',
+    tokenDesc: 'Manually configure NetEase Cloud Music login token',
+    tokenPlaceholder: 'Enter NetEase Cloud Music token',
     messages: {
-      proxySuccess: 'Proxy settings saved, restart required to take effect',
+      proxySuccess: 'Proxy settings saved, restart app to apply',
       proxyError: 'Please check your input',
-      realIPSuccess: 'RealIP settings saved',
-      realIPError: 'Please enter a valid IP address'
+      realIPSuccess: 'Real IP settings saved',
+      realIPError: 'Please enter a valid IP address',
+      tokenSuccess: 'Token settings saved, restart app to apply',
+      tokenError: 'Please enter a valid token'
     }
   },
   system: {

--- a/src/i18n/lang/ja-JP/settings.ts
+++ b/src/i18n/lang/ja-JP/settings.ts
@@ -93,20 +93,25 @@ export default {
   },
   network: {
     apiPort: '音楽APIポート',
-    apiPortDesc: '変更後はアプリの再起動が必要です',
+    apiPortDesc: '変更後はアプリを再起動してください',
     proxy: 'プロキシ設定',
-    proxyDesc: '音楽にアクセスできない場合はプロキシを有効にできます',
+    proxyDesc: '音楽にアクセスできない場合にプロキシを有効にできます',
     proxyHost: 'プロキシアドレス',
     proxyHostPlaceholder: 'プロキシアドレスを入力してください',
     proxyPort: 'プロキシポート',
     proxyPortPlaceholder: 'プロキシポートを入力してください',
     realIP: 'realIP設定',
-    realIPDesc: '制限により、このプロジェクトは海外での使用が制限されます。realIPパラメータを使用して国内IPを渡すことで解決できます',
+    realIPDesc: '制限により、このプロジェクトは海外で使用する際に制限を受ける可能性があり、realIPパラメータを使用して国内IPを渡すことで解決できます',
+    token: 'Token設定',
+    tokenDesc: 'NetEase Cloud Musicログイントークンを手動で設定',
+    tokenPlaceholder: 'NetEase Cloud Musicトークンを入力してください',
     messages: {
-      proxySuccess: 'プロキシ設定を保存しました。アプリ再起動後に有効になります',
-      proxyError: '入力が正しいかどうか確認してください',
-      realIPSuccess: '実IPアドレス設定を保存しました',
-      realIPError: '有効なIPアドレスを入力してください'
+      proxySuccess: 'プロキシ設定が保存されました。アプリを再起動して適用してください',
+      proxyError: '入力が正しいか確認してください',
+      realIPSuccess: 'realIP設定が保存されました',
+      realIPError: '有効なIPアドレスを入力してください',
+      tokenSuccess: 'Token設定が保存されました。アプリを再起動して適用してください',
+      tokenError: '有効なTokenを入力してください'
     }
   },
   system: {

--- a/src/i18n/lang/ko-KR/settings.ts
+++ b/src/i18n/lang/ko-KR/settings.ts
@@ -102,11 +102,16 @@ export default {
     proxyPortPlaceholder: '프록시 포트를 입력하세요',
     realIP: 'realIP 설정',
     realIPDesc: '제한으로 인해 이 프로젝트는 해외에서 사용할 때 제한을 받을 수 있으며, realIP 매개변수를 사용하여 국내 IP를 전달하여 해결할 수 있습니다',
+    token: 'Token 설정',
+    tokenDesc: 'NetEase Cloud Music 로그인 토큰을 수동으로 구성',
+    tokenPlaceholder: 'NetEase Cloud Music 토큰을 입력하세요',
     messages: {
       proxySuccess: '프록시 설정이 저장되었습니다. 앱을 재시작한 후 적용됩니다',
       proxyError: '입력이 올바른지 확인하세요',
       realIPSuccess: '실제 IP 설정이 저장되었습니다',
-      realIPError: '유효한 IP 주소를 입력하세요'
+      realIPError: '유효한 IP 주소를 입력하세요',
+      tokenSuccess: 'Token 설정이 저장되었습니다. 앱을 재시작한 후 적용됩니다',
+      tokenError: '유효한 Token을 입력하세요'
     }
   },
   system: {

--- a/src/i18n/lang/zh-CN/settings.ts
+++ b/src/i18n/lang/zh-CN/settings.ts
@@ -102,11 +102,16 @@ export default {
     proxyPortPlaceholder: '请输入代理端口',
     realIP: 'realIP设置',
     realIPDesc: '由于限制,此项目在国外使用会受到限制可使用realIP参数,传进国内IP解决',
+    token: 'Token设置',
+    tokenDesc: '手动配置网易云音乐登录Token',
+    tokenPlaceholder: '请输入网易云音乐Token',
     messages: {
       proxySuccess: '代理设置已保存，重启应用后生效',
       proxyError: '请检查输入是否正确',
       realIPSuccess: '真实IP设置已保存',
-      realIPError: '请输入有效的IP地址'
+      realIPError: '请输入有效的IP地址',
+      tokenSuccess: 'Token设置已保存，重启应用后生效',
+      tokenError: '请输入有效的Token'
     }
   },
   system: {

--- a/src/i18n/lang/zh-Hant/settings.ts
+++ b/src/i18n/lang/zh-Hant/settings.ts
@@ -92,21 +92,26 @@ export default {
     remoteControlDesc: '設定遠端控制功能'
   },
   network: {
-    apiPort: '音樂API連接埠',
-    apiPortDesc: '修改後需要重啟應用程式',
+    apiPort: '音樂API端口',
+    apiPortDesc: '修改後需要重啟應用',
     proxy: '代理設定',
-    proxyDesc: '無法存取音樂時可以開啟代理',
-    proxyHost: '代理位址',
-    proxyHostPlaceholder: '請輸入代理位址',
-    proxyPort: '代理連接埠',
-    proxyPortPlaceholder: '請輸入代理連接埠',
+    proxyDesc: '無法訪問音樂時可以開啟代理',
+    proxyHost: '代理地址',
+    proxyHostPlaceholder: '請輸入代理地址',
+    proxyPort: '代理端口',
+    proxyPortPlaceholder: '請輸入代理端口',
     realIP: 'realIP設定',
     realIPDesc: '由於限制,此項目在國外使用會受到限制可使用realIP參數,傳進國內IP解決',
+    token: 'Token設定',
+    tokenDesc: '手動配置網易雲音樂登錄Token',
+    tokenPlaceholder: '請輸入網易雲音樂Token',
     messages: {
-      proxySuccess: '代理設定已儲存，重啟應用程式後生效',
+      proxySuccess: '代理設定已保存，重啟應用後生效',
       proxyError: '請檢查輸入是否正確',
-      realIPSuccess: '真實IP設定已儲存',
-      realIPError: '請輸入有效的IP位址'
+      realIPSuccess: '真實IP設定已保存',
+      realIPError: '請輸入有效的IP地址',
+      tokenSuccess: 'Token設定已保存，重啟應用後生效',
+      tokenError: '請輸入有效的Token'
     }
   },
   system: {

--- a/src/renderer/views/set/index.vue
+++ b/src/renderer/views/set/index.vue
@@ -409,6 +409,18 @@
                 />
               </div>
             </div>
+
+            <div class="set-item">
+              <div>
+                <div class="set-item-title">{{ t('settings.network.token') }}</div>
+                <div class="set-item-content">{{ t('settings.network.tokenDesc') }}</div>
+              </div>
+              <div class="flex items-center gap-2">
+                <n-button size="small" @click="showTokenModal = true">{{
+                  t('common.configure')
+                }}</n-button>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -517,6 +529,13 @@
         @confirm="handleProxyConfirm"
       />
 
+      <!-- Token设置弹窗 -->
+      <token-settings
+        v-model:show="showTokenModal"
+        :token="currentToken"
+        @confirm="handleTokenConfirm"
+      />
+
       <!-- 音源设置弹窗 -->
       <music-source-settings v-model:show="showMusicSourcesModal" v-model:sources="musicSources" />
 
@@ -545,6 +564,7 @@ import MusicSourceSettings from '@/components/settings/MusicSourceSettings.vue';
 import ProxySettings from '@/components/settings/ProxySettings.vue';
 import RemoteControlSetting from '@/components/settings/ServerSetting.vue';
 import ShortcutSettings from '@/components/settings/ShortcutSettings.vue';
+import TokenSettings from '@/components/settings/TokenSettings.vue';
 import { useSettingsStore } from '@/store/modules/settings';
 import { useUserStore } from '@/store/modules/user';
 import { type Platform } from '@/types/music';
@@ -683,6 +703,10 @@ const proxyForm = ref({
   port: 7890
 });
 
+// Token设置相关
+const showTokenModal = ref(false);
+const currentToken = ref(localStorage.getItem('token') || '');
+
 // 使用 store 中的字体列表
 const systemFonts = computed(() => settingsStore.systemFonts);
 
@@ -770,6 +794,13 @@ const handleProxyConfirm = async (proxyConfig) => {
     }
   };
   message.success(t('settings.network.messages.proxySuccess'));
+};
+
+const handleTokenConfirm = async (tokenData: { token: string }) => {
+  // 保存token到localStorage
+  localStorage.setItem('token', tokenData.token);
+  currentToken.value = tokenData.token;
+  message.success(t('settings.network.messages.tokenSuccess'));
 };
 
 const validateAndSaveRealIP = () => {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
<img width="1200" height="780" alt="微信图片_20250803112753" src="https://github.com/user-attachments/assets/4f21c9a0-1168-4d7e-9c15-80684fcb97ce" />

- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/algerkong/AlgerMusicPlayer/issues/413
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案
**问题背景：**  
由于网易云音乐的登录接口常被网络环境拦截（如防火墙、反爬机制），导致用户无法正常登录，影响使用体验。
**解决方案：**  
在「设置」页面新增一个「手动输入 Token」的功能，允许用户通过外部方式获取 Token 后粘贴到软件中，绕过登录流程
**实现方式：**
- 在设置面板中添加 Token 输入框
- 支持保存 Token 到本地配置

### 📝 更新日志

- feat(settings): 支持手动输入 Token，解决网易云音乐登录被拦截问题  
  用户可在设置中直接填写 Token，绕过登录限制。

- fix(组件名称): 处理问题或特性描述 ...

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
