### PR TITLE
feat:添加手动输入 Token 功能，解决网易云音乐二维码登录被拦截问题

### DIFF
--- a/src/i18n/lang/en-US/settings.ts
+++ b/src/i18n/lang/en-US/settings.ts
@@ -104,11 +104,18 @@ export default {
     proxyPortPlaceholder: 'Enter proxy port',
     realIP: 'RealIP Settings',
     realIPDesc: 'Use realIP parameter with mainland China IP to resolve access restrictions abroad',
+    token: 'Token Settings',
+    tokenDesc: 'Manually configure authentication token',
+    tokenPlaceholder: 'Enter your authentication token here...',
+    tokenTip: 'You can manually enter your authentication token. After configuration, please restart the application for the changes to take effect.',
     messages: {
       proxySuccess: 'Proxy settings saved, restart required to take effect',
       proxyError: 'Please check your input',
       realIPSuccess: 'RealIP settings saved',
-      realIPError: 'Please enter a valid IP address'
+      realIPError: 'Please enter a valid IP address',
+      tokenSuccess: 'Token settings saved successfully',
+      tokenError: 'Please enter a valid token',
+      restartRequired: 'Please restart the application for the changes to take effect'
     }
   },
   system: {
@@ -168,7 +175,8 @@ export default {
   validation: {
     selectProxyProtocol: 'Please select proxy protocol',
     proxyHost: 'Please enter proxy host',
-    portNumber: 'Please enter a valid port number (1-65535)'
+    portNumber: 'Please enter a valid port number (1-65535)',
+    tokenRequired: 'Please enter a valid token'
   },
   lyricSettings: {
     title: 'Lyric Settings',

--- a/src/i18n/lang/ja-JP/settings.ts
+++ b/src/i18n/lang/ja-JP/settings.ts
@@ -102,11 +102,18 @@ export default {
     proxyPortPlaceholder: 'プロキシポートを入力してください',
     realIP: 'realIP設定',
     realIPDesc: '制限により、このプロジェクトは海外での使用が制限されます。realIPパラメータを使用して国内IPを渡すことで解決できます',
+    token: 'Token設定',
+    tokenDesc: '認証トークンを手動で設定',
+    tokenPlaceholder: '認証トークンを入力してください...',
+    tokenTip: '認証トークンを手動で入力できます。設定後、変更を有効にするためにアプリケーションを再起動してください。',
     messages: {
       proxySuccess: 'プロキシ設定を保存しました。アプリ再起動後に有効になります',
       proxyError: '入力が正しいかどうか確認してください',
       realIPSuccess: '実IPアドレス設定を保存しました',
-      realIPError: '有効なIPアドレスを入力してください'
+      realIPError: '有効なIPアドレスを入力してください',
+      tokenSuccess: 'Token設定を正常に保存しました',
+      tokenError: '有効なTokenを入力してください',
+      restartRequired: '変更を有効にするためにアプリケーションを再起動してください'
     }
   },
   system: {
@@ -166,7 +173,8 @@ export default {
   validation: {
     selectProxyProtocol: 'プロキシプロトコルを選択してください',
     proxyHost: 'プロキシアドレスを入力してください',
-    portNumber: '有効なポート番号を入力してください（1-65535）'
+    portNumber: '有効なポート番号を入力してください（1-65535）',
+    tokenRequired: '有効なTokenを入力してください'
   },
   lyricSettings: {
     title: '歌詞設定',

--- a/src/i18n/lang/ko-KR/settings.ts
+++ b/src/i18n/lang/ko-KR/settings.ts
@@ -102,11 +102,18 @@ export default {
     proxyPortPlaceholder: '프록시 포트를 입력하세요',
     realIP: 'realIP 설정',
     realIPDesc: '제한으로 인해 이 프로젝트는 해외에서 사용할 때 제한을 받을 수 있으며, realIP 매개변수를 사용하여 국내 IP를 전달하여 해결할 수 있습니다',
+    token: 'Token 설정',
+    tokenDesc: '인증 토큰을 수동으로 구성',
+    tokenPlaceholder: '인증 토큰을 입력하세요...',
+    tokenTip: '인증 토큰을 수동으로 입력할 수 있습니다. 구성 후 변경사항을 적용하려면 애플리케이션을 재시작하세요.',
     messages: {
       proxySuccess: '프록시 설정이 저장되었습니다. 앱을 재시작한 후 적용됩니다',
       proxyError: '입력이 올바른지 확인하세요',
       realIPSuccess: '실제 IP 설정이 저장되었습니다',
-      realIPError: '유효한 IP 주소를 입력하세요'
+      realIPError: '유효한 IP 주소를 입력하세요',
+      tokenSuccess: 'Token 설정이 성공적으로 저장되었습니다',
+      tokenError: '유효한 Token을 입력하세요',
+      restartRequired: '변경사항을 적용하려면 애플리케이션을 재시작하세요'
     }
   },
   system: {
@@ -166,7 +173,8 @@ export default {
   validation: {
     selectProxyProtocol: '프록시 프로토콜을 선택하세요',
     proxyHost: '프록시 주소를 입력하세요',
-    portNumber: '유효한 포트 번호를 입력하세요 (1-65535)'
+    portNumber: '유효한 포트 번호를 입력하세요 (1-65535)',
+    tokenRequired: '유효한 Token을 입력하세요'
   },
   lyricSettings: {
     title: '가사 설정',

--- a/src/i18n/lang/zh-CN/settings.ts
+++ b/src/i18n/lang/zh-CN/settings.ts
@@ -102,11 +102,18 @@ export default {
     proxyPortPlaceholder: '请输入代理端口',
     realIP: 'realIP设置',
     realIPDesc: '由于限制,此项目在国外使用会受到限制可使用realIP参数,传进国内IP解决',
+    token: 'Token设置',
+    tokenDesc: '手动配置认证令牌',
+    tokenPlaceholder: '请输入您的认证令牌...',
+    tokenTip: '您可以手动输入认证令牌。配置完成后，请重启应用程序以使更改生效。',
     messages: {
       proxySuccess: '代理设置已保存，重启应用后生效',
       proxyError: '请检查输入是否正确',
       realIPSuccess: '真实IP设置已保存',
-      realIPError: '请输入有效的IP地址'
+      realIPError: '请输入有效的IP地址',
+      tokenSuccess: 'Token设置已保存成功',
+      tokenError: '请输入有效的Token',
+      restartRequired: '请重启应用程序以使更改生效'
     }
   },
   system: {
@@ -166,7 +173,8 @@ export default {
   validation: {
     selectProxyProtocol: '请选择代理协议',
     proxyHost: '请输入代理地址',
-    portNumber: '请输入有效的端口号(1-65535)'
+    portNumber: '请输入有效的端口号(1-65535)',
+    tokenRequired: '请输入有效的Token'
   },
   lyricSettings: {
     title: '歌词设置',

--- a/src/i18n/lang/zh-Hant/settings.ts
+++ b/src/i18n/lang/zh-Hant/settings.ts
@@ -102,11 +102,18 @@ export default {
     proxyPortPlaceholder: '請輸入代理連接埠',
     realIP: 'realIP設定',
     realIPDesc: '由於限制,此項目在國外使用會受到限制可使用realIP參數,傳進國內IP解決',
+    token: 'Token設定',
+    tokenDesc: '手動配置認證令牌',
+    tokenPlaceholder: '請輸入您的認證令牌...',
+    tokenTip: '您可以手動輸入認證令牌。配置完成後，請重啟應用程式以使更改生效。',
     messages: {
       proxySuccess: '代理設定已儲存，重啟應用程式後生效',
       proxyError: '請檢查輸入是否正確',
       realIPSuccess: '真實IP設定已儲存',
-      realIPError: '請輸入有效的IP位址'
+      realIPError: '請輸入有效的IP位址',
+      tokenSuccess: 'Token設定已儲存成功',
+      tokenError: '請輸入有效的Token',
+      restartRequired: '請重啟應用程式以使更改生效'
     }
   },
   system: {
@@ -166,7 +173,8 @@ export default {
   validation: {
     selectProxyProtocol: '請選擇代理協議',
     proxyHost: '請輸入代理位址',
-    portNumber: '請輸入有效的連接埠號(1-65535)'
+    portNumber: '請輸入有效的連接埠號(1-65535)',
+    tokenRequired: '請輸入有效的Token'
   },
   lyricSettings: {
     title: '歌詞設定',

--- a/src/renderer/components/settings/TokenSettings.vue
+++ b/src/renderer/components/settings/TokenSettings.vue
@@ -1,0 +1,135 @@
+<template>
+  <n-modal
+    v-model:show="visible"
+    preset="dialog"
+    :title="t('settings.network.token')"
+    :positive-text="t('common.confirm')"
+    :negative-text="t('common.cancel')"
+    :show-icon="false"
+    @positive-click="handleTokenConfirm"
+    @negative-click="handleCancel"
+  >
+    <n-form
+      ref="formRef"
+      :model="tokenForm"
+      :rules="tokenRules"
+      label-placement="left"
+      label-width="80"
+      require-mark-placement="right-hanging"
+    >
+      <n-form-item :label="t('settings.network.token')" path="token">
+        <n-input
+          v-model:value="tokenForm.token"
+          type="textarea"
+          :placeholder="t('settings.network.tokenPlaceholder')"
+          :rows="4"
+          show-count
+          :maxlength="10000"
+        />
+      </n-form-item>
+      <div class="token-tip">
+        <i class="ri-information-line"></i>
+        <span>{{ t('settings.network.tokenTip') }}</span>
+      </div>
+    </n-form>
+  </n-modal>
+</template>
+
+<script setup lang="ts">
+import type { FormRules } from 'naive-ui';
+import { useMessage } from 'naive-ui';
+import { defineEmits, defineProps, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps({
+  show: {
+    type: Boolean,
+    default: false
+  }
+});
+
+const emit = defineEmits(['update:show', 'confirm']);
+
+const { t } = useI18n();
+const message = useMessage();
+const formRef = ref();
+
+const visible = ref(props.show);
+const tokenForm = ref({
+  token: ''
+});
+
+const tokenRules: FormRules = {
+  token: {
+    required: true,
+    message: t('settings.validation.tokenRequired'),
+    trigger: ['blur', 'change'],
+    validator: (_rule, value) => {
+      if (!value || value.trim() === '') {
+        return false;
+      }
+      // 简单的token格式验证（至少包含一些关键字符）
+      const tokenRegex = /[a-zA-Z0-9=_\-\.]+/;
+      return tokenRegex.test(value.trim());
+    }
+  }
+};
+
+// 同步外部show属性变化
+watch(
+  () => props.show,
+  (newVal) => {
+    visible.value = newVal;
+    if (newVal) {
+      // 打开弹窗时，从localStorage获取当前token
+      const currentToken = localStorage.getItem('token') || '';
+      tokenForm.value.token = currentToken;
+    }
+  }
+);
+
+// 同步内部visible变化
+watch(
+  () => visible.value,
+  (newVal) => {
+    emit('update:show', newVal);
+  }
+);
+
+const handleTokenConfirm = async () => {
+  try {
+    await formRef.value?.validate();
+    const token = tokenForm.value.token.trim();
+    console.log(token);
+    // 保存token到localStorage
+    localStorage.setItem('token', token);
+    console.log('实际长度：', tokenForm.value.token.trim().length);
+    emit('confirm', { token });
+    visible.value = false;
+    
+    // 显示成功消息和重启提示
+    message.success(t('settings.network.messages.tokenSuccess'));
+    message.info(t('settings.network.messages.restartRequired'));
+  } catch (err) {
+    console.error('Token设置验证失败:', err);
+    message.error(t('settings.network.messages.tokenError'));
+  }
+};
+
+const handleCancel = () => {
+  visible.value = false;
+};
+</script>
+
+<style lang="scss" scoped>
+.token-tip {
+  @apply flex items-start gap-2 mt-3 p-3 rounded-lg;
+  @apply bg-blue-50 dark:bg-blue-900/20;
+  @apply text-blue-600 dark:text-blue-400;
+  @apply text-sm;
+
+  i {
+    @apply mt-0.5 flex-shrink-0;
+  }
+}
+</style> 

--- a/src/renderer/views/set/index.vue
+++ b/src/renderer/views/set/index.vue
@@ -409,6 +409,16 @@
                 />
               </div>
             </div>
+
+            <div class="set-item">
+              <div>
+                <div class="set-item-title">{{ t('settings.network.token') }}</div>
+                <div class="set-item-content">{{ t('settings.network.tokenDesc') }}</div>
+              </div>
+              <n-button size="small" @click="showTokenModal = true">
+                {{ t('common.configure') }}
+              </n-button>
+            </div>
           </div>
         </div>
 
@@ -524,6 +534,9 @@
       <remote-control-setting v-model:visible="showRemoteControlModal" />
     </template>
 
+    <!-- Token设置弹窗 -->
+    <token-settings v-model:show="showTokenModal" />
+
     <!-- 清除缓存弹窗 -->
     <clear-cache-settings v-model:show="showClearCacheModal" @confirm="clearCache" />
   </div>
@@ -545,6 +558,7 @@ import MusicSourceSettings from '@/components/settings/MusicSourceSettings.vue';
 import ProxySettings from '@/components/settings/ProxySettings.vue';
 import RemoteControlSetting from '@/components/settings/ServerSetting.vue';
 import ShortcutSettings from '@/components/settings/ShortcutSettings.vue';
+import TokenSettings from '@/components/settings/TokenSettings.vue';
 import { useSettingsStore } from '@/store/modules/settings';
 import { useUserStore } from '@/store/modules/user';
 import { type Platform } from '@/types/music';
@@ -677,6 +691,7 @@ const openDownloadPath = () => {
 };
 
 const showProxyModal = ref(false);
+const showTokenModal = ref(false);
 const proxyForm = ref({
   protocol: 'http',
   host: '127.0.0.1',


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/algerkong/AlgerMusicPlayer/issues/413
### 💡 需求背景和解决方案
由于网易云音乐的登录接口常被网络环境拦截（如防火墙、反爬机制），导致用户无法正常登录，影响使用体验。

**解决方案：**  
在「设置」页面新增一个「手动输入 Token」的功能，允许用户通过外部方式获取 Token 后粘贴到软件中，绕过登录流程。

**实现方式：**
- 在设置面板中添加 Token 输入框
- 支持保存 Token 到本地配置

### 📝 更新日志

- feat(settings): 支持手动输入 Token，解决网易云音乐登录被拦截问题  
  用户可在设置中直接填写 Token，绕过登录限制。

- fix(组件名称): 处理问题或特性描述 ...

- [] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供（如为设置项，通常无需演示）
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
<img width="1200" height="780" alt="微信图片_20250803122548" src="https://github.com/user-attachments/assets/6f9581b0-0969-43df-84a0-a40ce5678337" />

