### PR TITLE
feat: 列表显示最高音质tag和vip歌曲tag

### DIFF
--- a/src/renderer/components/common/songItemCom/CompactSongItem.vue
+++ b/src/renderer/components/common/songItemCom/CompactSongItem.vue
@@ -44,6 +44,12 @@
             </n-ellipsis>
           </div>
           <div class="song-item-content-compact-artist">
+            <div class="song-tags mr-2">
+              <span v-if="getHighestQuality(item)" :class="getQualityClass(getHighestQuality(item))">
+                {{ getHighestQuality(item) }}
+              </span>
+              <span v-if="item.fee === 1" class="song-tag vip-tag">VIP</span>
+            </div>
             <n-ellipsis line-clamp="1">
               <template v-for="(artist, index) in artists" :key="index">
                 <span
@@ -174,6 +180,33 @@ const formatDuration = (ms: number): string => {
   const seconds = totalSeconds % 60;
   return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
 };
+
+// ==================== 新增: 音质判断逻辑 ====================
+/**
+ * 判断歌曲的最高音质
+ * @param song 歌曲对象
+ */
+const getHighestQuality = (song: SongResult): 'Hi-Res' | 'SQ' | 'HQ' | null => {
+  if (song.hr && song.hr.size > 0) return 'Hi-Res';
+  if (song.sq && song.sq.size > 0) return 'SQ';
+  if (song.h && song.h.size > 0) return 'HQ';
+  return null;
+};
+
+/**
+ * 根据音质获取对应的CSS类
+ * @param quality 音质字符串
+ */
+const getQualityClass = (quality: string | null): string => {
+  if (!quality) return '';
+  switch (quality) {
+    case 'Hi-Res': return 'song-tag hires-tag';
+    case 'SQ': return 'song-tag sq-tag';
+    case 'HQ': return 'song-tag hq-tag';
+    default: return '';
+  }
+};
+// ============================================================
 </script>
 
 <style lang="scss" scoped>
@@ -266,6 +299,50 @@ const formatDuration = (ms: number): string => {
     }
   }
 }
+
+// ==================== 标签样式 ====================
+.song-tags {
+  @apply flex items-center gap-1 flex-shrink-0;
+}
+
+.song-tag {
+  @apply text-xs px-1 py-0.5 rounded border;
+  transform: scale(0.85);
+  transform-origin: left center;
+  letter-spacing: 0.5px;
+  background-color: transparent !important;
+}
+
+.hires-tag {
+  @apply text-red-600 border-red-500/80 dark:text-red-400 dark:border-red-500/70;
+}
+
+.sq-tag {
+  @apply text-amber-600 border-amber-500/80 dark:text-amber-400 dark:border-amber-500/70;
+}
+
+.hq-tag {
+  @apply text-green-600 border-green-500/80 dark:text-green-400 dark:border-green-500/70;
+}
+
+.vip-tag {
+  @apply text-purple-600 border-purple-500/80 dark:text-purple-400 dark:border-purple-500/70;
+}
+
+.compact-song-item .song-item-content-compact-artist {
+  @apply flex items-center;
+  .song-tags {
+    margin-right: 2px;
+  }
+}
+
+.standard-song-item .song-item-content-name {
+  @apply flex items-center;
+  .song-tags {
+    margin-right: 4px;
+  }
+}
+// ======================================================
 
 // 全局应用
 :deep(.text-ellipsis) {

--- a/src/renderer/components/common/songItemCom/StandardSongItem.vue
+++ b/src/renderer/components/common/songItemCom/StandardSongItem.vue
@@ -44,7 +44,13 @@
             >{{ item.name }}</n-ellipsis
           >
         </div>
-        <div class="song-item-content-name">
+        <div class="song-item-content-name flex items-center">
+          <div class="song-tags mr-2">
+              <span v-if="getHighestQuality(item)" :class="getQualityClass(getHighestQuality(item))">
+                {{ getHighestQuality(item) }}
+              </span>
+            <span v-if="item.fee === 1" class="song-tag vip-tag">VIP</span>
+          </div>
           <n-ellipsis class="text-ellipsis" line-clamp="1">
             <template v-for="(artist, index) in artists" :key="index">
               <span
@@ -150,6 +156,32 @@ const onPlayMusic = () => {
 const onPlayNext = () => {
   baseItem.value?.handlePlayNext();
 };
+// ==================== 音质判断逻辑 ====================
+/**
+ * 判断歌曲的最高音质
+ * @param song 歌曲对象
+ */
+const getHighestQuality = (song: SongResult): 'Hi-Res' | 'SQ' | 'HQ' | null => {
+  if (song.hr && song.hr.size > 0) return 'Hi-Res';
+  if (song.sq && song.sq.size > 0) return 'SQ';
+  if (song.h && song.h.size > 0) return 'HQ';
+  return null;
+};
+
+/**
+ * 根据音质获取对应的CSS类
+ * @param quality 音质字符串
+ */
+const getQualityClass = (quality: string | null): string => {
+  if (!quality) return '';
+  switch (quality) {
+    case 'Hi-Res': return 'song-tag hires-tag';
+    case 'SQ': return 'song-tag sq-tag';
+    case 'HQ': return 'song-tag hq-tag';
+    default: return '';
+  }
+};
+// ============================================================
 </script>
 
 <style lang="scss" scoped>
@@ -216,4 +248,48 @@ const onPlayNext = () => {
     @apply mr-3 cursor-pointer;
   }
 }
+
+// ==================== 标签样式 ====================
+.song-tags {
+  @apply flex items-center flex-shrink-0;
+}
+
+.song-tag {
+  @apply text-xs px-1 py-0.5 rounded border;
+  transform: scale(0.85);
+  transform-origin: left center;
+  letter-spacing: 0.5px;
+  background-color: transparent !important;
+}
+
+.hires-tag {
+  @apply text-red-600 border-red-500/80 dark:text-red-400 dark:border-red-500/70;
+}
+
+.sq-tag {
+  @apply text-amber-600 border-amber-500/80 dark:text-amber-400 dark:border-amber-500/70;
+}
+
+.hq-tag {
+  @apply text-green-600 border-green-500/80 dark:text-green-400 dark:border-green-500/70;
+}
+
+.vip-tag {
+  @apply text-purple-600 border-purple-500/80 dark:text-purple-400 dark:border-purple-500/70;
+}
+
+.compact-song-item .song-item-content-compact-artist {
+  @apply flex items-center;
+  .song-tags {
+    margin-right: 2px;
+  }
+}
+
+.standard-song-item .song-item-content-name {
+  @apply flex items-center;
+  .song-tags {
+    margin-right: 4px;
+  }
+}
+// ======================================================
 </style>

--- a/src/renderer/types/music.ts
+++ b/src/renderer/types/music.ts
@@ -52,6 +52,21 @@ export interface SongResult {
   duration?: number;
   dt?: number;
   isFirstPlay?: boolean;
+  fee?: number; // 1 表示 VIP 歌曲
+
+  // 音质信息
+  hr?: {
+    size: number;
+    [key: string]: any;
+  } | null;
+  sq?: {
+    size: number;
+    [key: string]: any;
+  } | null;
+  h?: {
+    size: number;
+    [key: string]: any;
+  } | null;
 }
 
 export interface Song {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

增加音质tag显示 （显示歌曲最高音质的tag HQ SQ Hi-Res VIP）
<img width="1530" height="1020" alt="image" src="https://github.com/user-attachments/assets/53eed40c-5c17-4276-9d3b-fda70a19dfaf" />


### 📝 更新日志

增加音质tag显示

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
