### PR TITLE
fix: 下载无损格式会返回hires音质的问题

### DIFF
--- a/src/renderer/api/music.ts
+++ b/src/renderer/api/music.ts
@@ -30,6 +30,8 @@ export const getMusicUrl = async (id: number, isDownloaded: boolean = false) => 
         params: {
           id,
           level: settingStore.setData.musicQuality || 'higher',
+          encodeType: settingStore.setData.musicQuality == 'lossless' ? 'aac' : 'flac',
+          // level为lossless时，encodeType=flac时网易云会返回hires音质，encodeType=aac时网易云会返回lossless音质
           cookie: `${localStorage.getItem('token')} os=pc;`
         }
       });
@@ -45,7 +47,8 @@ export const getMusicUrl = async (id: number, isDownloaded: boolean = false) => 
   return await request.get('/song/url/v1', {
     params: {
       id,
-      level: settingStore.setData.musicQuality || 'higher'
+      level: settingStore.setData.musicQuality || 'higher',
+      encodeType: settingStore.setData.musicQuality == 'lossless' ? 'aac' : 'flac'
     }
   });
 };


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无

### 💡 需求背景和解决方案

依赖包的api中encodeType是写死的flac，而网易云音乐获取url的接口在下面参数时
```
level: 'lossless',
encodeType: 'flac'
```
若歌曲存在hires，会返回hires音质，除非指定encodeType为aac，本次提交只是加了参数encodeType，还需要依赖包修改song_url_v1那个文件，改成encodeType: query.encodeType从查询参数中获取

### 📝 更新日志

解决下载歌曲时设置flac音质，结果可能下载到hires音质的问题


- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
