### PR TITLE
feat: 优化歌单懒加载加载策略，并修复播放栏遮挡问题

### DIFF
--- a/src/renderer/views/download/DownloadPage.vue
+++ b/src/renderer/views/download/DownloadPage.vue
@@ -122,49 +122,66 @@
             </div>
 
             <div class="downloaded-items">
-              <div v-for="item in downList" :key="item.path" class="downloaded-item">
-                <div class="item-cover">
-                  <img :src="getImgUrl(item.picUrl, '200y200')" alt="Cover" />
-                </div>
-                <div class="item-info flex items-center gap-4 w-full">
-                  <div
-                    class="item-name min-w-[160px] max-w-[160px] truncate"
-                    :title="item.displayName || item.filename"
-                  >
-                    {{ item.displayName || item.filename }}
+              <n-virtual-list
+                ref="downloadedListRef"
+                class="virtual-list"
+                :style="{ height: isPlay ? 'calc(100vh - 210px)' : 'calc(100vh - 130px)' }"
+                :items="downList"
+                :item-size="80"
+                item-resizable
+                key-field="path"
+                @scroll="handleVirtualScroll"
+              >
+                <template #default="{ item }">
+                  <div class="downloaded-item">
+                    <div class="item-cover">
+                      <img :src="getImgUrl(item.picUrl, '200y200')" alt="Cover" />
+                    </div>
+                    <div class="item-info flex items-center gap-4 w-full">
+                      <div
+                        class="item-name min-w-[160px] max-w-[160px] truncate"
+                        :title="item.displayName || item.filename"
+                      >
+                        {{ item.displayName || item.filename }}
+                      </div>
+                      <div
+                        class="item-artist min-w-[120px] max-w-[120px] flex items-center gap-1 truncate"
+                      >
+                        <i class="iconfont ri-user-line"></i>
+                        <span>{{ item.ar?.map((a) => a.name).join(', ') }}</span>
+                      </div>
+                      <div class="item-size min-w-[80px] max-w-[80px] flex items-center gap-1">
+                        <i class="iconfont ri-file-line"></i>
+                        <span>{{ formatSize(item.size) }}</span>
+                      </div>
+                      <div
+                        class="item-path min-w-[220px] max-w-[220px] flex items-center gap-1"
+                        :title="item.path"
+                      >
+                        <i class="iconfont ri-folder-path-line"></i>
+                        <span>{{ shortenPath(item.path) }}</span>
+                        <button class="copy-button" @click="copyPath(item.path)">
+                          <i class="iconfont ri-file-copy-line"></i>
+                        </button>
+                      </div>
+                      <div class="item-actions flex gap-1 ml-2">
+                        <button class="action-btn play" @click="handlePlayMusic(item)">
+                          <i class="iconfont ri-play-circle-line"></i>
+                        </button>
+                        <button class="action-btn open" @click="openDirectory(item.path)">
+                          <i class="iconfont ri-folder-open-line"></i>
+                        </button>
+                        <button class="action-btn delete" @click="handleDelete(item)">
+                          <i class="iconfont ri-delete-bin-line"></i>
+                        </button>
+                      </div>
+                    </div>
                   </div>
-                  <div
-                    class="item-artist min-w-[120px] max-w-[120px] flex items-center gap-1 truncate"
-                  >
-                    <i class="iconfont ri-user-line"></i>
-                    <span>{{ item.ar?.map((a) => a.name).join(', ') }}</span>
-                  </div>
-                  <div class="item-size min-w-[80px] max-w-[80px] flex items-center gap-1">
-                    <i class="iconfont ri-file-line"></i>
-                    <span>{{ formatSize(item.size) }}</span>
-                  </div>
-                  <div
-                    class="item-path min-w-[220px] max-w-[220px] flex items-center gap-1"
-                    :title="item.path"
-                  >
-                    <i class="iconfont ri-folder-path-line"></i>
-                    <span>{{ shortenPath(item.path) }}</span>
-                    <button class="copy-button" @click="copyPath(item.path)">
-                      <i class="iconfont ri-file-copy-line"></i>
-                    </button>
-                  </div>
-                  <div class="item-actions flex gap-1 ml-2">
-                    <button class="action-btn play" @click="handlePlayMusic(item)">
-                      <i class="iconfont ri-play-circle-line"></i>
-                    </button>
-                    <button class="action-btn open" @click="openDirectory(item.path)">
-                      <i class="iconfont ri-folder-open-line"></i>
-                    </button>
-                    <button class="action-btn delete" @click="handleDelete(item)">
-                      <i class="iconfont ri-delete-bin-line"></i>
-                    </button>
-                  </div>
-                </div>
+                </template>
+              </n-virtual-list>
+              <div v-if="isLoadingDownloaded && downloadedList.length > 0" class="loading-more">
+                <n-spin size="small" />
+                <span class="ml-2">{{ t('download.loading') }}</span>
               </div>
             </div>
           </template>
@@ -464,6 +481,7 @@ const downloadedList = ref<DownloadedItem[]>(
 );
 
 const downList = computed(() => downloadedList.value);
+const isPlay = computed(() => !!playerStore.playMusicUrl);
 
 // 计算总进度
 const totalProgress = computed(() => {
@@ -679,41 +697,88 @@ const formatSongName = (songInfo) => {
     .replace(/\{albumName\}/g, albumName);
 };
 
-// 获取已下载音乐列表
-const refreshDownloadedList = async () => {
-  if (isLoadingDownloaded.value) return; // 防止重复加载
+// 全量本地记录
+const allLocalRecords = ref<any[]>([]);
+// 当前页码
+const page = ref(1);
+// 每页大小
+const pageSize = 50;
+const hasMore = ref(true);
+const scrollbarRef = ref();
+
+// 加载更多已下载音乐（从本地全量数据中分批读取并获取详情）
+const loadMoreDownloaded = async () => {
+  if (isLoadingDownloaded.value || !hasMore.value) return;
 
   try {
     isLoadingDownloaded.value = true;
-    const list = await window.electron.ipcRenderer.invoke('get-downloaded-music');
-
-    if (!Array.isArray(list) || list.length === 0) {
-      downloadedList.value = [];
-      localStorage.setItem('downloadedList', '[]');
+    
+    // 计算当前批次的切片范围
+    const start = (page.value - 1) * pageSize;
+    const end = start + pageSize;
+    
+    // 获取当前批次的本地记录
+    const batchRecords = allLocalRecords.value.slice(start, end);
+    
+    if (batchRecords.length === 0) {
+      hasMore.value = false;
       return;
     }
 
+    // 处理这一批次的数据：获取云端详情
+    const processedBatch = await processBatchRecords(batchRecords);
+    
+    // 追加到显示列表
+    if (page.value === 1) {
+      downloadedList.value = processedBatch;
+    } else {
+      downloadedList.value = [...downloadedList.value, ...processedBatch];
+    }
+    
+    // 更新页码和状态
+    if (end >= allLocalRecords.value.length) {
+      hasMore.value = false;
+    } else {
+      page.value++;
+    }
+
+    // 缓存当前的显示列表（注意：随着列表变大，可能需要限制缓存大小或只缓存前几页）
+    // 这里为了性能，我们只缓存已加载的部分，但要注意 storage 容量限制
+    // 实际生产中建议只缓存ID或前100条，这里暂时保持原逻辑缓存全部已加载的
+    try {
+      localStorage.setItem('downloadedList', JSON.stringify(downloadedList.value));
+    } catch(e) {
+      console.warn('LocalStorage quota exceeded or error', e);
+    }
+
+  } catch (error) {
+    console.error('加载更多下载记录失败:', error);
+  } finally {
+    isLoadingDownloaded.value = false;
+  }
+};
+
+// 处理一批记录：获取详情、格式化
+const processBatchRecords = async (list: any[]): Promise<DownloadedItem[]> => {
     const songIds = list.filter((item) => item.id).map((item) => item.id);
+    
+    // 如果这批没有ID，直接返回格式化后的本地记录
     if (songIds.length === 0) {
-      // 处理显示格式化文件名
-      const updatedList = list.map((item) => ({
+      return list.map((item) => ({
         ...item,
         displayName: formatSongName(item) || item.filename
       }));
-
-      downloadedList.value = updatedList;
-      localStorage.setItem('downloadedList', JSON.stringify(updatedList));
-      return;
     }
 
     try {
+      // 批量获取详情
       const detailRes = await getMusicDetail(songIds);
       const songDetails = detailRes.data.songs.reduce((acc, song) => {
         acc[song.id] = song;
         return acc;
       }, {});
 
-      const updatedList = list.map((item) => {
+      return list.map((item) => {
         const songDetail = songDetails[item.id];
         const updatedItem = {
           ...item,
@@ -721,31 +786,64 @@ const refreshDownloadedList = async () => {
           ar: songDetail?.ar || item.ar || [{ name: t('download.localMusic') }],
           name: songDetail?.name || item.name || item.filename
         };
-
-        // 添加格式化的显示名称
         updatedItem.displayName = formatSongName(updatedItem) || updatedItem.filename;
         return updatedItem;
       });
-
-      downloadedList.value = updatedList;
-      localStorage.setItem('downloadedList', JSON.stringify(updatedList));
     } catch (error) {
-      console.error('Failed to get music details:', error);
-      // 处理显示格式化文件名
-      const updatedList = list.map((item) => ({
+      console.error('获取详情失败，回退到本地信息', error);
+      return list.map((item) => ({
         ...item,
         displayName: formatSongName(item) || item.filename
       }));
-
-      downloadedList.value = updatedList;
-      localStorage.setItem('downloadedList', JSON.stringify(updatedList));
     }
+};
+
+// 初始化/刷新列表：读取所有本地文件记录，重置分页，加载第一页
+const refreshDownloadedList = async () => {
+  if (isLoadingDownloaded.value) return;
+
+  try {
+    isLoadingDownloaded.value = true;
+    // 1. 获取所有本地记录（仅元数据，很快）
+    const list = await window.electron.ipcRenderer.invoke('get-downloaded-music');
+
+    if (!Array.isArray(list) || list.length === 0) {
+      allLocalRecords.value = [];
+      downloadedList.value = [];
+      localStorage.setItem('downloadedList', '[]');
+      hasMore.value = false;
+      return;
+    }
+    
+    // 2. 保存全量索引
+    allLocalRecords.value = list;
+    
+    // 3. 重置状态
+    page.value = 1;
+    hasMore.value = true;
+    downloadedList.value = [];
+    
+    // 4. 释放Loading锁以便 loadMoreDownloaded 可以执行 (实际上 loadMoreDownloaded 也会加锁，所以这里直接调内部逻辑或手动重置锁)
+    isLoadingDownloaded.value = false; 
+    
+    // 5. 加载第一页
+    await loadMoreDownloaded();
+
   } catch (error) {
-    console.error('Failed to get downloaded music list:', error);
+    console.error('Failed to refresh list:', error);
     downloadedList.value = [];
     localStorage.setItem('downloadedList', '[]');
   } finally {
     isLoadingDownloaded.value = false;
+  }
+};
+
+// 虚拟列表滚动处理
+const handleVirtualScroll = (e: any) => {
+  const { scrollTop, scrollHeight, clientHeight } = e.target;
+  const threshold = 200;
+  if (scrollHeight - scrollTop - clientHeight < threshold && !isLoadingDownloaded.value && hasMore.value) {
+    loadMoreDownloaded();
   }
 };
 

--- a/src/renderer/views/favorite/index.vue
+++ b/src/renderer/views/favorite/index.vue
@@ -62,24 +62,36 @@
       </div>
     </div>
     <div class="favorite-main" :class="setAnimationClass('animate__bounceInRight')">
-      <n-scrollbar ref="scrollbarRef" class="favorite-content" @scroll="handleScroll">
+      <div class="favorite-content">
         <div v-if="favoriteList.length === 0" class="empty-tip">
           <n-empty :description="t('favorite.emptyTip')" />
         </div>
         <div v-else class="favorite-list" :class="{ 'max-w-[400px]': isComponent }">
-          <song-item
-            v-for="(song, index) in favoriteSongs"
-            :key="song.id"
-            :item="song"
-            :favorite="false"
-            class="favorite-list-item"
-            :class="setAnimationClass('animate__bounceInLeft')"
-            :style="getItemAnimationDelay(index)"
-            :selectable="isSelecting"
-            :selected="selectedSongs.includes(song.id as number)"
-            @play="handlePlay"
-            @select="handleSelect"
-          />
+          <n-virtual-list
+            ref="virtualListRef"
+            class="virtual-list"
+            :style="{ height: isPlay ? 'calc(100vh - 210px)' : 'calc(100vh - 130px)' }"
+            :items="favoriteSongs"
+            :item-size="64"
+            item-resizable
+            key-field="id"
+            @scroll="handleScroll"
+          >
+            <template #default="{ item, index }">
+              <song-item
+                :key="item.id"
+                :item="item"
+                :favorite="false"
+                class="favorite-list-item"
+                :class="setAnimationClass('animate__bounceInLeft')"
+                :style="getItemAnimationDelay(index)"
+                :selectable="isSelecting"
+                :selected="selectedSongs.includes(item.id as number)"
+                @play="handlePlay"
+                @select="handleSelect"
+              />
+            </template>
+          </n-virtual-list>
 
           <div v-if="isComponent" class="favorite-list-more text-center">
             <n-button text type="primary" @click="handleMore">{{ t('common.viewMore') }}</n-button>
@@ -92,7 +104,7 @@
           <div v-if="noMore" class="no-more-tip">{{ t('common.noMore') }}</div>
         </div>
         <play-bottom />
-      </n-scrollbar>
+      </div>
     </div>
   </div>
 </template>
@@ -114,6 +126,7 @@ import { isElectron, setAnimationClass, setAnimationDelay } from '@/utils';
 const { t } = useI18n();
 const playerStore = usePlayerStore();
 const favoriteList = computed(() => playerStore.favoriteList);
+const isPlay = computed(() => !!playerStore.playMusicUrl);
 const favoriteSongs = ref<SongResult[]>([]);
 const loading = ref(false);
 const noMore = ref(false);

--- a/src/renderer/views/music/MusicListPage.vue
+++ b/src/renderer/views/music/MusicListPage.vue
@@ -193,7 +193,7 @@
               <n-virtual-list
                 ref="songListRef"
                 class="song-virtual-list"
-                style="max-height: calc(100vh - 130px)"
+                :style="{ maxHeight: isPlay ? 'calc(100vh - 220px)' : 'calc(100vh - 130px)' }"
                 :items="filteredSongs"
                 :item-size="isCompactLayout ? 50 : 70"
                 item-resizable
@@ -215,7 +215,6 @@
                         @select="(id, selected) => handleSelect(id, selected)"
                       />
                     </div>
-                    <div v-if="index === filteredSongs.length - 1" class="h-36"></div>
                   </div>
                 </template>
               </n-virtual-list>
@@ -300,6 +299,8 @@ const canRemove = computed(() => {
 
 const canCollect = ref(false);
 const isCollected = ref(false);
+
+const isPlay = computed(() => !!playerStore.playMusicUrl && !isMobile.value);
 
 const page = ref(0);
 const pageSize = 40;
@@ -787,7 +788,12 @@ watch(
   () => listInfo.value,
   (newListInfo) => {
     if (newListInfo?.trackIds) {
-      loadFullPlaylist();
+      // 不再自动加载完整列表，改为惰性加载
+      // loadFullPlaylist();
+
+      // 重置列表状态并加载第一页
+      resetListState();
+      loadMoreSongs();
     }
   },
   { deep: true }


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [x] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue
https://github.com/algerkong/AlgerMusicPlayer/issues/547
<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->
### 1. 要解决的具体问题 (The specific problem being resolved)

- **性能问题**：当且仅当列表项（已下载、本地音乐、大歌单）数量较多（>500）时，页面加载会出现显著卡顿（主要由一次性全量请求和大量 DOM 渲染引起）。

- **布局 Bug**：底部播放栏（PlayBottom）在播放状态下会遮挡列表的最后几项，导致无法操作。

- 内存优化

  ：旧有的普通列表渲染 ( v-for ) 在长列表中占用大量内存，影响应用稳定性。

### 2. 最终实现的 API 和用法 (Final API Implementation & Usage)

#### A. 下载页面 (DownloadPage) - 懒加载重构

将原有的全量加载重构为**分批懒加载**模式：

```typescript
// 核心逻辑：本地文件全量读取 -> 内存切片 -> 分批请求详情

const loadMoreDownloaded = async () => {
  // 1. 获取当前批次的本地文件记录 (Batch Size: 50)
  const batchRecords = allLocalRecords.value.slice(start, end);
  // 2. 仅请求当前批次的云端详情
  const processedBatch = await getMusicDetail(ids);
  // 3. 追加到显示列表
  downloadedList.value = [...downloadedList.value, ...processedBatch];
}
```

#### B. 虚拟列表集成 (Virtual List Integration)

在 DownloadPage、FavoritePage 和 MusicListPage 中统一引入 <n-virtual-list>：

```html
<n-virtual-list
  :items="displayList"
  :item-size="64" <!-- 固定高度优化渲染 -->
  key-field="id"
  @scroll="handleVirtualScroll" <!-- 滚动触底触发加载 -->
  :style="{ height: isPlay ? 'calc(100vh - 210px)' : 'calc(100vh - 130px)' }" <!-- 动态高度 -->
>
  <template #default="{ item }">
    <song-item :item="item" />
  </template>
</n-virtual-list>
```

### 3. UI/交互变动 (UI/Interaction Changes)

#### ✅ 布局修复 (Layout Fix)

播放栏不再遮挡列表底部：
<img width="2560" height="238" alt="PixPin_2026-01-08_21-31-51" src="https://github.com/user-attachments/assets/bcf87919-2b96-48c0-ad21-92487e4facb4" />

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

1. **针对下载页面的优化：**
   ```text
   perf(DownloadPage): refactor to use batch lazy loading and virtual list
   ```
2. **针对收藏页面的优化：**
   ```text
   perf(FavoritePage): replace standard list with n-virtual-list
   ```
3. **针对布局遮挡修复：**
   ```text
   fix(Layout): prevent player bar from obscuring list bottom content
   ```

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
