### PR TITLE
add main-process cursor presence sync for lyric window

### DIFF
--- a/src/main/lyric.ts
+++ b/src/main/lyric.ts
@@ -10,6 +10,54 @@ let isDragging = false;
 
 // 添加窗口大小变化防护
 let originalSize = { width: 0, height: 0 };
+let mousePresenceTimer: ReturnType<typeof setInterval> | null = null;
+let lastMouseInside: boolean | null = null;
+
+const isPointInsideWindow = (
+  point: { x: number; y: number },
+  bounds: { x: number; y: number; width: number; height: number }
+) => {
+  return (
+    point.x >= bounds.x &&
+    point.x < bounds.x + bounds.width &&
+    point.y >= bounds.y &&
+    point.y < bounds.y + bounds.height
+  );
+};
+
+const stopMousePresenceTracking = () => {
+  if (mousePresenceTimer) {
+    clearInterval(mousePresenceTimer);
+    mousePresenceTimer = null;
+  }
+  lastMouseInside = null;
+};
+
+const emitMousePresence = () => {
+  if (!lyricWindow || lyricWindow.isDestroyed()) return;
+
+  const mousePoint = screen.getCursorScreenPoint();
+  const bounds = lyricWindow.getBounds();
+  const isInside = isPointInsideWindow(mousePoint, bounds);
+
+  if (isInside === lastMouseInside) return;
+
+  lastMouseInside = isInside;
+  lyricWindow.webContents.send('lyric-mouse-presence', isInside);
+};
+
+const startMousePresenceTracking = () => {
+  if (mousePresenceTimer) return;
+
+  emitMousePresence();
+  mousePresenceTimer = setInterval(() => {
+    if (!lyricWindow || lyricWindow.isDestroyed()) {
+      stopMousePresenceTracking();
+      return;
+    }
+    emitMousePresence();
+  }, 50);
+};
 
 const createWin = () => {
   console.log('Creating lyric window');
@@ -102,6 +150,7 @@ const createWin = () => {
 
   // 监听窗口关闭事件
   lyricWindow.on('closed', () => {
+    stopMousePresenceTracking();
     if (lyricWindow) {
       lyricWindow.destroy();
       lyricWindow = null;
@@ -135,6 +184,7 @@ export const loadLyricWindow = (ipcMain: IpcMain, mainWin: BrowserWindow): void 
       }
       lyricWindow.focus();
       lyricWindow.show();
+      startMousePresenceTracking();
       return true;
     }
     return false;
@@ -169,6 +219,7 @@ export const loadLyricWindow = (ipcMain: IpcMain, mainWin: BrowserWindow): void 
     win.once('ready-to-show', () => {
       console.log('Lyric window ready to show');
       win.show();
+      startMousePresenceTracking();
     });
   });
 
@@ -197,6 +248,7 @@ export const loadLyricWindow = (ipcMain: IpcMain, mainWin: BrowserWindow): void 
 
   ipcMain.on('close-lyric', () => {
     if (lyricWindow && !lyricWindow.isDestroyed()) {
+      stopMousePresenceTracking();
       lyricWindow.webContents.send('lyric-window-close');
       mainWin.webContents.send('lyric-control-back', 'close');
       mainWin.webContents.send('lyric-window-closed');

--- a/src/renderer/views/lyric/index.vue
+++ b/src/renderer/views/lyric/index.vue
@@ -341,6 +341,7 @@ const displayMode = computed(() => lyricSetting.value.displayMode);
 const showTranslation = computed(() => lyricSetting.value.showTranslation);
 
 let hideControlsTimer: number | null = null;
+let removeMousePresenceListener: (() => void) | null = null;
 
 const isHovering = ref(false);
 
@@ -782,10 +783,25 @@ onMounted(() => {
 
   // 通知主窗口歌词窗口已就绪，请求发送完整歌词数据
   windowData.electron.ipcRenderer.send('lyric-ready');
+
+  removeMousePresenceListener = window.ipcRenderer.on(
+    'lyric-mouse-presence',
+    (isInside: boolean) => {
+      isHovering.value = isInside;
+
+      if (lyricSetting.value.isLock) {
+        windowData.electron.ipcRenderer.send('set-ignore-mouse', !isInside);
+      }
+    }
+  );
 });
 
 onUnmounted(() => {
   window.removeEventListener('resize', updateContainerHeight);
+  if (removeMousePresenceListener) {
+    removeMousePresenceListener();
+    removeMousePresenceListener = null;
+  }
 });
 
 const checkTheme = () => {


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [x] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [x] 其他（Electron 主进程与渲染进程事件同步修复）

### 🔗 相关 Issue

- #606 歌词锁定后，锁图标一直显示，不自动隐藏 (经测试，歌词悬窗拥有共同问题)

### 💡 需求背景和解决方案


问题背景：
- 预期行为：鼠标移出歌词悬窗应隐藏悬窗；鼠标移入悬窗范围内再显示。
- 实际行为：在“快速移出”场景下，`mouseleave` 事件有概率丢失，导致 `isHovering` 未被纠正，锁图标残留显示。

https://github.com/user-attachments/assets/2df7f795-a0d1-4b96-8716-dd064d59931e



解决方案：
1. 在主进程 `src/main/lyric.ts` 增加周期性鼠标位置检测（50ms）：
   - 使用 `screen.getCursorScreenPoint()` + `lyricWindow.getBounds()` 判断鼠标是否在歌词窗范围内。
   - 仅在状态变化时向歌词窗发送 `lyric-mouse-presence` 事件。

2. 在渲染进程 `src/renderer/views/lyric/index.vue` 监听 `lyric-mouse-presence`：
   - 将回传状态同步到 `isHovering`，作为悬停状态纠偏来源。
   - 锁定状态下根据 `isInside` 发送 `set-ignore-mouse`：
     - `isInside = true` -> 不穿透
     - `isInside = false` -> 穿透

3. 生命周期清理：
   - 主进程在窗口关闭/销毁时停止检测定时器。
   - 渲染进程在组件卸载时移除监听器，避免重复订阅与泄漏。

验证结果：
- 鼠标快速移出时，悬窗可正确隐藏。
- 鼠标重新进入歌词悬窗范围内，悬窗可正确显示。
- 多次快速移入/移出复现不再出现残留显示。

https://github.com/user-attachments/assets/522d157a-ca43-45cc-8ce2-d3071179dc2b


### 📝 更新日志

- fix(歌词悬窗): 修复鼠标快速移出歌词悬窗时悬窗偶现不隐藏的问题（通过主进程周期检测鼠标是否在窗内并回传纠正悬停状态）

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

