### PR TITLE
fix(download): 下载设置抽屉打开时路径显示为空

### DIFF
--- a/src/main/modules/downloadManager.ts
+++ b/src/main/modules/downloadManager.ts
@@ -523,7 +523,7 @@ class DownloadManager {
       } else {
         // Full response (200) - start from beginning
         task.loaded = 0;
-        const contentLength = response.headers['content-length'];
+        const contentLength = response.headers['content-length'] as string;
         task.total = contentLength ? parseInt(contentLength, 10) : 0;
       }
 

--- a/src/renderer/views/download/DownloadPage.vue
+++ b/src/renderer/views/download/DownloadPage.vue
@@ -915,16 +915,16 @@ const saveDownloadSettings = () => {
 };
 
 const initDownloadSettings = async () => {
-  const path = await window.electron.ipcRenderer.invoke('get-store-value', 'set.downloadPath');
-  const nameFormat = await window.electron.ipcRenderer.invoke(
+  const path = window.electron.ipcRenderer.sendSync('get-store-value', 'set.downloadPath');
+  const nameFormat = window.electron.ipcRenderer.sendSync(
     'get-store-value',
     'set.downloadNameFormat'
   );
-  const separator = await window.electron.ipcRenderer.invoke(
+  const separator = window.electron.ipcRenderer.sendSync(
     'get-store-value',
     'set.downloadSeparator'
   );
-  const saveLyric = await window.electron.ipcRenderer.invoke(
+  const saveLyric = window.electron.ipcRenderer.sendSync(
     'get-store-value',
     'set.downloadSaveLyric'
   );


### PR DESCRIPTION

<!--
首先，感谢你的贡献！😄
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

- 现象：保存下载路径后，再次打开下载设置抽屉打开时路径显示为空

- 修复：get-store-value 主进程用 ipcMain.on 同步返回，renderer 却用 invoke 读取会直接 reject，导致 initDownloadSettings 中断、已保存的下载路径等配置回读失败。改为 sendSync，与项目其它调用点保持一致。

- 额外信息：contentLength 类型错误非本次提交引入，因无法通过 precommit 检查，故一并修复。

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(download): 下载设置抽屉打开时路径显示为空
- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
