### PR TITLE
fix(local-music): 修复本地音乐播放失败、进度异常与切歌失效

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,8 @@ AGENTS.md
 .auto-imports.d.ts
 .components.d.ts
 
+# TypeScript 增量编译缓存
+*.tsbuildinfo
+
 src/renderer/auto-imports.d.ts
 src/renderer/components.d.ts

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,23 @@
 import { electronApp, optimizer } from '@electron-toolkit/utils';
-import { app, ipcMain, nativeImage, session } from 'electron';
+import { app, ipcMain, nativeImage, protocol, session } from 'electron';
 import { join } from 'path';
+
+// 必须在 app.whenReady() 之前注册自定义协议为特权协议，
+// 否则 http(s) 页面（dev server、生产环境的 file://）无法把 local:// 当成
+// 安全/可 fetch/可流式的资源加载，会触发 CORS 拦截或 net::ERR_UNKNOWN_URL_SCHEME
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: 'local',
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      bypassCSP: true,
+      corsEnabled: true
+    }
+  }
+]);
 
 import type { Language } from '../i18n/main';
 import i18n from '../i18n/main';

--- a/src/main/modules/fileManager.ts
+++ b/src/main/modules/fileManager.ts
@@ -1,7 +1,8 @@
-import { app, dialog, ipcMain, protocol, shell } from 'electron';
+import { app, dialog, ipcMain, net, protocol, shell } from 'electron';
 import Store from 'electron-store';
 import * as fs from 'fs';
 import * as path from 'path';
+import { pathToFileURL } from 'url';
 
 import { getStore } from './config';
 
@@ -28,31 +29,35 @@ function sanitizeFilename(filename: string): string {
  */
 export function initializeFileManager() {
   // 注册本地文件协议
-  protocol.registerFileProtocol('local', (request, callback) => {
+  // Electron 25+ 起 registerFileProtocol 已弃用，改用 protocol.handle，并配合 main/index.ts
+  // 中的 registerSchemesAsPrivileged，让 audio 元素能从 http(s) 页面跨协议加载本地文件
+  protocol.handle('local', async (request) => {
     try {
-      const url = request.url;
-      // local://C:/Users/xxx.mp3
-      let filePath = decodeURIComponent(url.replace('local:///', ''));
+      // local:///<absolute-path>
+      let filePath = decodeURIComponent(request.url.replace(/^local:\/\/\/?/, ''));
 
-      // 兼容 local:///C:/Users/xxx.mp3 这种情况
+      // Windows: 协议解析后可能是 /C:/...，去掉前导斜杠
       if (/^\/[a-zA-Z]:\//.test(filePath)) {
         filePath = filePath.slice(1);
       }
 
-      // 还原为系统路径格式
-      filePath = path.normalize(filePath);
-
-      // 检查文件是否存在
-      if (!fs.existsSync(filePath)) {
-        console.error('File not found:', filePath);
-        callback({ error: -6 }); // net::ERR_FILE_NOT_FOUND
-        return;
+      // macOS/Linux 上去掉前导斜杠后会丢失绝对路径标识，这里补回
+      if (process.platform !== 'win32' && !filePath.startsWith('/')) {
+        filePath = '/' + filePath;
       }
 
-      callback({ path: filePath });
+      filePath = path.normalize(filePath);
+
+      if (!fs.existsSync(filePath)) {
+        console.error('File not found:', filePath);
+        return new Response(null, { status: 404 });
+      }
+
+      // 用 net.fetch 走 file:// 加载，自动支持 Range / streaming，让媒体元素能正常 seek
+      return net.fetch(pathToFileURL(filePath).toString());
     } catch (error) {
       console.error('Error handling local protocol:', error);
-      callback({ error: -2 }); // net::FAILED
+      return new Response(null, { status: 500 });
     }
   });
 

--- a/src/main/modules/fileManager.ts
+++ b/src/main/modules/fileManager.ts
@@ -1,8 +1,8 @@
-import { app, dialog, ipcMain, net, protocol, shell } from 'electron';
+import { app, dialog, ipcMain, protocol, shell } from 'electron';
 import Store from 'electron-store';
 import * as fs from 'fs';
 import * as path from 'path';
-import { pathToFileURL } from 'url';
+import { Readable } from 'stream';
 
 import { getStore } from './config';
 
@@ -22,6 +22,45 @@ function sanitizeFilename(filename: string): string {
     .replace(/[<>:"/\\|?*]/g, '_')
     .replace(/\s+/g, ' ')
     .trim();
+}
+
+// Electron net.fetch(file://) 在当前版本不会回 206，audio seek 需要主进程自己处理 Range
+function buildLocalFileResponse(
+  filePath: string,
+  total: number,
+  rangeHeader: string | null
+): Response {
+  const range416 = () =>
+    new Response(null, { status: 416, headers: { 'Content-Range': `bytes */${total}` } });
+
+  let start = 0;
+  let end = total - 1;
+  let partial = false;
+
+  if (rangeHeader) {
+    const m = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim());
+    if (!m || (!m[1] && !m[2])) return range416();
+    if (m[1]) {
+      start = parseInt(m[1], 10);
+      if (m[2]) end = Math.min(parseInt(m[2], 10), end);
+    } else {
+      start = Math.max(0, total - parseInt(m[2], 10));
+    }
+    if (start > end || start >= total) return range416();
+    partial = true;
+  }
+
+  return new Response(
+    Readable.toWeb(fs.createReadStream(filePath, { start, end })) as ReadableStream,
+    {
+      status: partial ? 206 : 200,
+      headers: {
+        'Content-Length': String(end - start + 1),
+        'Accept-Ranges': 'bytes',
+        ...(partial && { 'Content-Range': `bytes ${start}-${end}/${total}` })
+      }
+    }
+  );
 }
 
 /**
@@ -48,13 +87,13 @@ export function initializeFileManager() {
 
       filePath = path.normalize(filePath);
 
-      if (!fs.existsSync(filePath)) {
+      const stat = await fs.promises.stat(filePath).catch(() => null);
+      if (!stat?.isFile()) {
         console.error('File not found:', filePath);
         return new Response(null, { status: 404 });
       }
 
-      // 用 net.fetch 走 file:// 加载，自动支持 Range / streaming，让媒体元素能正常 seek
-      return net.fetch(pathToFileURL(filePath).toString());
+      return buildLocalFileResponse(filePath, stat.size, request.headers.get('range'));
     } catch (error) {
       console.error('Error handling local protocol:', error);
       return new Response(null, { status: 500 });

--- a/src/renderer/components/common/songItemCom/BaseSongItem.vue
+++ b/src/renderer/components/common/songItemCom/BaseSongItem.vue
@@ -4,7 +4,7 @@
     @contextmenu.prevent="handleContextMenu"
     @mouseenter="handleMouseEnter"
     @mouseleave="handleMouseLeave"
-    @dblclick.stop="playMusicEvent(item)"
+    @dblclick.stop="handlePlay(item)"
   >
     <slot name="index"></slot>
     <slot name="select" v-if="selectable"></slot>
@@ -22,7 +22,7 @@
       :is-dislike="isDislike"
       :can-remove="canRemove"
       @update:show="showDropdown = $event"
-      @play="playMusicEvent(item)"
+      @play="handlePlay(item)"
       @play-next="handlePlayNext"
       @download="downloadMusic(item)"
       @download-lyric="downloadLyric(item)"
@@ -81,6 +81,12 @@ const imageLoad = async (event: Event) => {
   const target = event.target as HTMLImageElement;
   if (!target) return;
   await handleImageLoad(target);
+};
+
+// 双击和右键菜单"播放"统一入口：先通知父组件设置播放列表上下文，再触发播放
+const handlePlay = (song: SongResult) => {
+  emits('play', song);
+  playMusicEvent(song);
 };
 
 // 切换选择状态


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

- Closes #647 本地播放失败
- Closes #626 本地播放进度不对

### 💡 需求背景和解决方案

集中修复本地音乐播放链路上的三个独立 bug，外加一项 chore。

#### 1. 本地音乐播放失败：`local://` 协议被 CORS 拦截（#647）

`local://` 在 Chromium 默认 scheme 下被当作普通 web 协议拒绝跨域，audio 元素加载本地文件直接报 CORS。

**方案**：通过 `protocol.registerSchemesAsPrivileged` 把 `local` 注册为特权 scheme（standard / secure / supportFetchAPI / stream / corsEnabled / bypassCSP），绕过同源策略；同时用 Electron 25+ 推荐的 `protocol.handle` 替换已弃用的 `registerFileProtocol`，并修复 macOS/Linux 去掉前导斜杠后丢失绝对路径前缀的问题。

#### 2. 本地音乐 seek / 快进失效，恢复播放从 0 开始（#626）

切到 `protocol.handle` 后 audio 元素的 Range 请求会带头到主进程，但 `net.fetch(file://)` 既不识别 Range 也不带 `Accept-Ranges`，浏览器认为 `local://` 不支持随机访问 → seek 时只能从头加载，退出后恢复播放也回到 0。

**方案**：新增 `buildLocalFileResponse` 自己处理 Range：

- 无 Range：`200` + `Accept-Ranges: bytes`
- 有 Range：`206` + `Content-Range`，`fs.createReadStream` 切片返回
- 非法 Range：`416` + `Content-Range: bytes */total`

顺手把 `fs.existsSync` 换成 `stat`，一次拿文件大小且过滤掉目录。

#### 3. 双击 / 右键菜单播放后切歌失效

`BaseSongItem` 双击和右键菜单 "播放" 只调了 `setPlay`，没 emit `'play'` → 父组件 `setPlayList` 不执行，导致从本地音乐列表双击进入后无法切上下一首。

**方案**：抽统一入口先 emit 再触发播放，与点击播放按钮行为对齐。

#### 4. chore

`.gitignore` 忽略 `*.tsbuildinfo` 编译缓存。

### 📝 更新日志

- fix(local-music): 注册 local 协议为特权 scheme，修复本地音乐 CORS 报错（#647）
- fix(local-music): 主进程实现 Range/206，让本地音乐 seek / 快进恢复（#626）
- fix(player): 双击 / 右键菜单播放时同步设置播放列表上下文，修复切歌失效

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供