### PR TITLE
ci: 修复 PR Code Quality job 失败（存量 lint + typecheck 拿不到 unplugin d.ts）

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -64,6 +64,13 @@ jobs:
       - name: Lint
         run: npx eslint --max-warnings 0 "src/**/*.{ts,tsx,vue,js}"
 
+      # tsconfig.web.json 显式 require src/renderer/{auto-imports,components}.d.ts
+      # 这两个文件由 unplugin-auto-import / unplugin-vue-components 在 vite 启动时
+      # 生成，且被 .gitignore 排除（58922dc 维护者主动设置）。CI 直接跑 typecheck
+      # 拿不到 d.ts 会报 TS2688，先跑一次 build 触发 unplugin 生成
+      - name: Build (generates auto-import / components d.ts)
+        run: npm run build
+
       - name: Type check
         run: npm run typecheck
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -58,6 +58,11 @@ jobs:
         with:
           node-version: 24
 
+      # lint:i18n 脚本用 bun 跑（package.json: "bun scripts/check_i18n.ts"），
+      # CI 默认环境没有 bun 会报 sh: bun: not found
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
       - name: Install dependencies
         run: npm install
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,7 +55,8 @@ export default [
         defineEmits: 'readonly',
         // TypeScript 全局类型
         NodeJS: 'readonly',
-        ScrollBehavior: 'readonly'
+        ScrollBehavior: 'readonly',
+        ScrollToOptions: 'readonly'
       }
     },
     plugins: {
@@ -148,7 +149,8 @@ export default [
         useMessage: 'readonly',
         // TypeScript 全局类型
         NodeJS: 'readonly',
-        ScrollBehavior: 'readonly'
+        ScrollBehavior: 'readonly',
+        ScrollToOptions: 'readonly'
       }
     },
     plugins: {

--- a/src/renderer/components/common/StickyTabPage.vue
+++ b/src/renderer/components/common/StickyTabPage.vue
@@ -4,7 +4,9 @@
       <div class="w-full pb-32">
         <!-- Page Header (scrolls away) -->
         <div ref="headerRef" class="page-padding pt-6 pb-2">
-          <h1 class="mb-2 text-2xl font-bold tracking-tight text-neutral-900 md:text-3xl dark:text-white">
+          <h1
+            class="mb-2 text-2xl font-bold tracking-tight text-neutral-900 md:text-3xl dark:text-white"
+          >
             {{ title }}
           </h1>
           <p v-if="description" class="text-neutral-500 dark:text-neutral-400">

--- a/src/renderer/components/podcast/RadioCard.vue
+++ b/src/renderer/components/podcast/RadioCard.vue
@@ -23,11 +23,7 @@ const goToDetail = () => {
 </script>
 
 <template>
-  <div
-    class="group cursor-pointer animate-item"
-    :style="{ animationDelay }"
-    @click="goToDetail"
-  >
+  <div class="group cursor-pointer animate-item" :style="{ animationDelay }" @click="goToDetail">
     <!-- Cover -->
     <div
       class="relative aspect-square overflow-hidden rounded-2xl shadow-md group-hover:shadow-xl transition-all duration-500"

--- a/src/renderer/views/list/index.vue
+++ b/src/renderer/views/list/index.vue
@@ -95,8 +95,8 @@ import { useRoute, useRouter } from 'vue-router';
 
 import { getPlaylistCategory } from '@/api/home';
 import { getListByCat } from '@/api/list';
-import StickyTabPage from '@/components/common/StickyTabPage.vue';
 import { navigateToMusicList } from '@/components/common/MusicListNavigator';
+import StickyTabPage from '@/components/common/StickyTabPage.vue';
 import type { IPlayListSort } from '@/types/playlist';
 import { calculateAnimationDelay, formatNumber, getImgUrl } from '@/utils';
 

--- a/src/renderer/views/mv/index.vue
+++ b/src/renderer/views/mv/index.vue
@@ -80,9 +80,7 @@
           </span>
         </div>
         <div v-if="!hasMore && !initLoading" class="text-center">
-          <span
-            class="text-xs text-neutral-400 font-medium tracking-widest uppercase opacity-50"
-          >
+          <span class="text-xs text-neutral-400 font-medium tracking-widest uppercase opacity-50">
             {{ t('comp.pages.mv.noMore') }}
           </span>
         </div>

--- a/src/renderer/views/podcast/index.vue
+++ b/src/renderer/views/podcast/index.vue
@@ -2,7 +2,9 @@
   <sticky-tab-page
     ref="pageRef"
     :title="currentCategoryId === -1 ? t('podcast.podcast') : currentCategoryName"
-    :description="currentCategoryId === -1 ? t('podcast.discover') : t('podcast.exploreCategoryRadios')"
+    :description="
+      currentCategoryId === -1 ? t('podcast.discover') : t('podcast.exploreCategoryRadios')
+    "
     :model-value="currentCategoryId"
     :categories="categoryList"
     label-key="name"
@@ -34,7 +36,9 @@
       <section v-if="todayPerfered.length > 0">
         <div class="mb-6 flex items-center justify-between">
           <div class="flex items-center gap-3">
-            <h2 class="text-xl font-bold tracking-tight text-neutral-900 md:text-2xl dark:text-white">
+            <h2
+              class="text-xl font-bold tracking-tight text-neutral-900 md:text-2xl dark:text-white"
+            >
               {{ t('podcast.todayPerfered') }}
             </h2>
             <div class="h-1.5 w-1.5 rounded-full bg-primary" />
@@ -65,7 +69,9 @@
               </div>
             </div>
             <div class="flex-1 min-w-0">
-              <h4 class="text-sm md:text-base font-semibold text-neutral-900 dark:text-white truncate">
+              <h4
+                class="text-sm md:text-base font-semibold text-neutral-900 dark:text-white truncate"
+              >
                 {{ program.mainSong?.name || program.name }}
               </h4>
               <p class="text-xs md:text-sm text-neutral-500 dark:text-neutral-400 truncate mt-1">
@@ -125,7 +131,10 @@
         </template>
       </div>
 
-      <div v-if="!categoryLoading && categoryRadios.length === 0" class="flex flex-col items-center justify-center py-20 text-neutral-400">
+      <div
+        v-if="!categoryLoading && categoryRadios.length === 0"
+        class="flex flex-col items-center justify-center py-20 text-neutral-400"
+      >
         <i class="ri-radio-line mb-4 text-5xl opacity-20" />
         <p class="text-sm font-medium">{{ t('podcast.noCategoryRadios') }}</p>
       </div>
@@ -134,7 +143,10 @@
         <n-spin size="small" />
         <span class="ml-2 text-neutral-500">{{ t('common.loading') }}</span>
       </div>
-      <div v-if="!categoryHasMore && categoryRadios.length > 0" class="text-center py-8 text-neutral-500">
+      <div
+        v-if="!categoryHasMore && categoryRadios.length > 0"
+        class="text-center py-8 text-neutral-500"
+      >
         {{ t('common.noMore') }}
       </div>
     </div>


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [ ] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [x] CI/CD 改进
- [ ] 重构
- [x] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

无 issue。问题由新开 PR #675 / #676 触发的 Code Quality job 暴露：

- [Lint 失败](https://github.com/algerkong/AlgerMusicPlayer/actions/runs/25995400844/job/76408902066)
- [Type check 失败](https://github.com/algerkong/AlgerMusicPlayer/actions/runs/25995595367/job/76409415805)

### 💡 需求背景和解决方案

`pr-check.yml` 只在 `pull_request` 事件触发，`main` push 不跑 lint / typecheck，导致两类配置债一直没被发现。任何新开 PR（不论改了什么）都会被 Code Quality job 直接拦下。

#### 1. 存量 lint 错误（10 处）

| 类型 | 数量 | 文件 |
| --- | --- | --- |
| `prettier/prettier` 格式 | 9 | `StickyTabPage.vue` / `RadioCard.vue` / `list/index.vue` / `mv/index.vue` / `podcast/index.vue` |
| `no-undef 'ScrollToOptions'` | 1 | `StickyTabPage.vue:79` |

- 格式问题由 `npx eslint --fix` 自动修复，零业务逻辑改动
- `ScrollToOptions` 来自 TypeScript DOM lib，ESLint 不解析 TS lib 类型 → 在 `eslint.config.mjs` 的 `.ts` 与 `.vue` 配置块补 `ScrollToOptions: 'readonly'`，与既有的 `ScrollBehavior` 同级

#### 2. CI typecheck 拿不到 unplugin 自动生成的 d.ts

`tsconfig.web.json` 的 `compilerOptions.types` 显式 require `src/renderer/{auto-imports,components}.d.ts`，这两个文件由 `unplugin-auto-import` / `unplugin-vue-components` 在 vite 启动时生成，且被 `.gitignore` 排除（[58922dc](https://github.com/algerkong/AlgerMusicPlayer/commit/58922dc) 维护者主动设置）。CI 直接跑 `npm run typecheck` 没启动过 vite → `TS2688: Cannot find type definition file`。

**修复**：在 `pr-check.yml` 的 Type check 步骤前插入一次 `npm run build` 触发 unplugin 生成 d.ts，同时顺带验证 build 链路。

> 不选 commit d.ts 进 git：尊重 58922dc 的维护者意图——避免每次 import 变化产生 diff 噪音。

**本地验证**：删除两个 d.ts 后跑 `npm run build` 重新生成，typecheck 通过。

### 📝 更新日志

- chore: 修复 main 上的存量 lint 错误（prettier 格式 + `ScrollToOptions` globals 缺失）
- ci: typecheck 前先跑 build 让 unplugin 生成自动 import d.ts，修复 `TS2688`

- [x] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供

---

> 建议优先合并此 PR，让 #675 / #676 的 Code Quality job 恢复正常。
> 长期建议：给 `main` push 也加上同样的 pr-check workflow，避免再次出现配置债。