### PR TITLE
perf(download): 下载落盘改为异步 IO，避免拷贝文件阻塞主进程

### DIFF
--- a/src/main/modules/downloadManager.ts
+++ b/src/main/modules/downloadManager.ts
@@ -650,21 +650,6 @@ class DownloadManager {
       fileExtension = `.${task.type || 'mp3'}`;
     }
 
-    // Build final file path with dedup
-    let finalFilePath = path.join(downloadPath, `${sanitizedFilename}${fileExtension}`);
-    let counter = 1;
-    while (fs.existsSync(finalFilePath)) {
-      const ext = path.extname(finalFilePath);
-      const base = path.join(downloadPath, sanitizedFilename);
-      finalFilePath = `${base} (${counter})${ext}`;
-      counter++;
-    }
-
-    // Move temp to final
-    fs.copyFileSync(task.tempFilePath, finalFilePath);
-    fs.unlinkSync(task.tempFilePath);
-    task.finalFilePath = finalFilePath;
-
     // Download lyrics
     let lyricsContent = '';
     let lyricData = null;
@@ -745,6 +730,10 @@ class DownloadManager {
     }
 
     // Write metadata
+    // 标签写入在临时文件（本地临时目录）上完成，之后再拷贝到下载目录：
+    // 1. 写标签需要整文件读 + 整文件写，在慢速磁盘或网络挂载盘（如 SMB / NFS）上代价很高，
+    //    放在本地临时文件上做可以把下载目录的写入压缩成一次拷贝；
+    // 2. 下载目录里的文件一出现就是带完整标签的，不会出现「先无标签、稍后被改写」的中间态。
     // songInfo may carry extra fields (song, no, publishTime) beyond DownloadSongInfo
     const info: any = task.songInfo;
     const fileFormat = fileExtension.toLowerCase();
@@ -753,8 +742,6 @@ class DownloadManager {
 
     if (['.mp3'].includes(fileFormat)) {
       try {
-        NodeID3.removeTags(finalFilePath);
-
         const tags = {
           title: info?.name,
           artist: artistNames,
@@ -776,10 +763,10 @@ class DownloadManager {
           year: info?.publishTime ? new Date(info.publishTime).getFullYear().toString() : undefined
         };
 
-        const success = NodeID3.write(tags, finalFilePath);
-        if (!success) {
-          console.error('Failed to write ID3 tags');
-        }
+        // 用 Promise API 走异步 IO，避免同步读写阻塞主进程。
+        // write 内部已经会剔除文件里原有的 ID3 帧，不需要额外调用 removeTags，
+        // 少一轮整文件读写。写入失败会 reject，由下面的 catch 统一处理。
+        await NodeID3.Promise.write(tags, task.tempFilePath);
       } catch (err) {
         console.error('Error writing ID3 tags:', err);
       }
@@ -799,12 +786,21 @@ class DownloadManager {
             tagMap,
             picture: coverImageBuffer ? { buffer: coverImageBuffer, mime: 'image/jpeg' } : undefined
           },
-          finalFilePath
+          task.tempFilePath
         );
       } catch (err) {
         console.error('Error writing FLAC tags:', err);
       }
     }
+
+    // Move temp to final
+    const finalFilePath = await this.moveToDownloadPath(
+      task.tempFilePath,
+      downloadPath,
+      sanitizedFilename,
+      fileExtension
+    );
+    task.finalFilePath = finalFilePath;
 
     // Save .lrc file if setting enabled
     if (lyricsContent && configStore.get('set.downloadSaveLyric')) {
@@ -901,6 +897,45 @@ class DownloadManager {
     // Remove completed task from active tasks and persist
     this.tasks.delete(task.taskId);
     this.persistQueue();
+  }
+
+  /**
+   * 把临时文件拷贝到下载目录并删除临时文件，返回最终文件路径。
+   *
+   * - 全程使用异步 IO：同步拷贝会在整个拷贝期间阻塞主进程（渲染进程 IPC、
+   *   托盘、快捷键全部卡住），文件越大、目标磁盘越慢越明显，
+   *   下载目录指向网络挂载盘（如 SMB / NFS）时尤其严重。
+   * - 同名文件依次尝试 " (1)"、" (2)" 后缀。这里靠 COPYFILE_EXCL 而不是先
+   *   existsSync 再拷贝：目标已存在时内核直接返回 EEXIST，「判断 + 写入」是
+   *   一次原子操作，既避免并发下载同名歌曲时互相覆盖，也少一轮文件系统往返。
+   */
+  private async moveToDownloadPath(
+    tempFilePath: string,
+    downloadPath: string,
+    sanitizedFilename: string,
+    fileExtension: string
+  ): Promise<string> {
+    const MAX_DEDUP_ATTEMPTS = 1000;
+    let finalFilePath = path.join(downloadPath, `${sanitizedFilename}${fileExtension}`);
+
+    for (let counter = 1; ; counter++) {
+      try {
+        await fs.promises.copyFile(tempFilePath, finalFilePath, fs.constants.COPYFILE_EXCL);
+        break;
+      } catch (error: any) {
+        // 非「目标已存在」的错误直接抛出；重名次数兜底，避免异常文件系统语义下无限重试
+        if (error?.code !== 'EEXIST' || counter > MAX_DEDUP_ATTEMPTS) {
+          throw error;
+        }
+        finalFilePath = path.join(
+          downloadPath,
+          `${sanitizedFilename} (${counter})${fileExtension}`
+        );
+      }
+    }
+
+    await fs.promises.unlink(tempFilePath);
+    return finalFilePath;
   }
 
   // ─── Batch error tracking ──────────────────────────────────────

--- a/src/main/modules/downloadManager.ts
+++ b/src/main/modules/downloadManager.ts
@@ -339,21 +339,24 @@ class DownloadManager {
 
   private async deleteCompleted(filePath: string): Promise<boolean> {
     try {
-      if (fs.existsSync(filePath)) {
-        try {
-          await fs.promises.unlink(filePath);
-        } catch (error) {
-          console.error('Error deleting file:', error);
+      // 直接 unlink：既省掉一次同步 stat（下载目录可能在慢速磁盘或网络挂载盘上，
+      // 同步调用会阻塞主进程），也避免 exists 之后文件被别处删除的竞态。
+      try {
+        await fs.promises.unlink(filePath);
+      } catch (error: any) {
+        // 文件本就不存在，保留记录交给 getCompleted 清理
+        if (error?.code === 'ENOENT') {
+          return false;
         }
-
-        const configStore = getStore();
-        const songInfos = (configStore.get('downloadedSongs') || {}) as Record<string, any>;
-        delete songInfos[filePath];
-        configStore.set('downloadedSongs', songInfos);
-
-        return true;
+        console.error('Error deleting file:', error);
       }
-      return false;
+
+      const configStore = getStore();
+      const songInfos = (configStore.get('downloadedSongs') || {}) as Record<string, any>;
+      delete songInfos[filePath];
+      configStore.set('downloadedSongs', songInfos);
+
+      return true;
     } catch (error) {
       console.error('Error deleting file:', error);
       return false;
@@ -370,12 +373,17 @@ class DownloadManager {
 
   private async getEmbeddedLyrics(filePath: string): Promise<string | null> {
     try {
-      if (!fs.existsSync(filePath)) return null;
+      const exists = await fs.promises
+        .access(filePath)
+        .then(() => true)
+        .catch(() => false);
+      if (!exists) return null;
 
       const ext = path.extname(filePath).toLowerCase();
 
       if (ext === '.mp3') {
-        const tags = NodeID3.read(filePath);
+        // Promise API 走异步 IO：读标签需要读入整个文件，同步读会阻塞主进程
+        const tags = await NodeID3.Promise.read(filePath);
         if (tags && tags.unsynchronisedLyrics) {
           const uslt = tags.unsynchronisedLyrics as any;
           return uslt.text || (typeof uslt === 'string' ? uslt : null);


### PR DESCRIPTION
### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [x] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

没有对应的 open issue，自己用的时候发现的：下载目录设成 SMB 共享盘，每首歌下载完界面都会卡住几秒。

同类症状的历史 issue（都已关闭，成因也是下载模块的同步 IO，这次把剩下的几处清掉了）：#58、#62、#140、#150。

### 💡 需求背景和解决方案

`downloadManager` 的落盘环节用的是同步 IO，拷贝期间主进程整个被占住，IPC、托盘、快捷键一起停。文件越大、目标磁盘越慢越明显，下载目录指向网络挂载盘时最严重。

改动都在 `src/main/modules/downloadManager.ts`：

1. `copyFileSync` / `unlinkSync` 换成 `fs.promises` 版本，这段逻辑收进新增的 `moveToDownloadPath()`。
2. 重名去重原来是 `while (existsSync)` 找空位再拷贝，改成拷贝时带 `COPYFILE_EXCL`、撞 `EEXIST` 就换 `" (n)"` 后缀重试。「判断存在 + 写入」合成一次原子操作，顺手修掉并发下载同名歌曲时互相覆盖的竞态，也少一轮文件系统往返。另外加了重试次数上限兜底。
3. ID3 / FLAC 标签改成先写在本地临时文件上，写完再拷到下载目录。写标签是整文件读进内存再整文件写回，原来对着下载目录做等于多两轮全量 IO。附带好处是下载目录里的文件一出现就带完整标签，没有「先无标签、稍后被改写」的中间态。
4. 删掉 `NodeID3.removeTags` 调用：`write` 内部的 `writeInBuffer` 第一步就是 `removeTagsFromBuffer`，这一轮整文件读写是白跑的。`write` 换成 `NodeID3.Promise.write`。
5. 同一模块另外两处同步调用一并改掉。`deleteCompleted` 去掉 `existsSync` 直接 `unlink` 再按错误码分流，顺带消除 exists 与 unlink 之间的竞态；`getEmbeddedLyrics` 的 `NodeID3.read` 换成 `Promise.read`（读标签要把整个文件读进内存，几十 MB 的文件同步读代价不小）。

剩下的同步调用没动：`os.tmpdir()` 下临时目录的那几个元数据操作在本地磁盘上，`persistQueueSync` 在退出路径上必须同步。

对外行为不变：文件命名规则（`歌名.mp3`、`歌名 (1).mp3`）、标签内容、`deleteCompleted` 的返回值语义都和改动前一致。

验证：`npm run typecheck`、`eslint`、`npm run build` 通过。另外写脚本确认了重名依次生成 `(1)` `(2)`、4 个并发拷同名目标得到 4 个不同文件名不互相覆盖、`.tmp` 上写的标签和歌词拷贝后能完整读回、目标目录不存在时抛 `ENOENT` 而不是死循环、临时文件在成功和失败路径都被清理。

### 📝 更新日志

- perf(download): 下载保存不再阻塞主进程，下载目录在网络盘或慢速磁盘上时界面不会卡顿；修复并发下载同名歌曲可能互相覆盖的问题

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
